### PR TITLE
Add example climate.set_hvac_mode action

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ climate:
 ```yaml
     # Example Action.
     set_hvac_mode:
-      # allows me to disable sending commands to aircon via UI.
+      # Allows you to control an existing Home Assistant HVAC device
       - service: climate.set_hvac_mode
         data:
           entity_id: "climate.bedroom_ac_nottemplate"

--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ climate:
       # could also send IR command via broadlink service calls etc.
 ```
 
+### Example action to control existing Home Assistant devices
+
+```yaml
+    # Example Action.
+    set_hvac_mode:
+      # allows me to disable sending commands to aircon via UI.
+      - service: climate.set_hvac_mode
+        data:
+          entity_id: "climate.bedroom_ac_nottemplate"
+          hvac_mode: "{{states('climate.bedroom_ac_template')}}"
+```
+
 ### Use Cases
 
 - Merge multiple components into one climate device (just like any template platform).


### PR DESCRIPTION
Add example Home Assistant service: climate.set_hvac_mode action to control existing devices to readme.md
I am adding this because I spent time trying to figure this out myself so I figured I would share this example.