### PR TITLE
Fix: Add ON_OFF feature support for entities with HVACMode.OFF

### DIFF
--- a/custom_components/climate_template/climate.py
+++ b/custom_components/climate_template/climate.py
@@ -232,7 +232,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
         self._unit_of_measurement = hass.config.units.temperature_unit
         self._attr_supported_features = 0
 
-        if HVACMode.OFF in self._attr_hvac_modes and len(self._attr_hvac_modes) > 1:
+        if HVACMode.OFF in config[CONF_MODE_LIST] and len(config[CONF_MODE_LIST]) > 1:
             self._attr_supported_features |= ClimateEntityFeature.ON_OFF
 
         self._attr_hvac_modes = config[CONF_MODE_LIST]


### PR DESCRIPTION
Resolves a warning related to entities implementing HVACMode.OFF without explicitly declaring the ClimateEntityFeature.ON_OFF feature. Fixes https://github.com/jcwillox/hass-template-climate/issues/76