### PR TITLE
fix: guard against None in state template handlers

### DIFF
--- a/custom_components/climate_template/climate.py
+++ b/custom_components/climate_template/climate.py
@@ -570,7 +570,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_min_temp(self, temp):
-        if temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if temp not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 self._attr_min_temp = float(temp)
             except ValueError:
@@ -578,7 +578,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_max_temp(self, temp):
-        if temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if temp not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 self._attr_max_temp = float(temp)
             except ValueError:
@@ -586,7 +586,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_current_temp(self, temp):
-        if temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if temp not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 self._attr_current_temperature = float(temp)
             except ValueError:
@@ -594,7 +594,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_current_humidity(self, humidity):
-        if humidity not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if humidity not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 self._attr_current_humidity = int(humidity)
             except ValueError:
@@ -602,7 +602,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_min_humidity(self, humidity):
-        if humidity not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if humidity not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 self._attr_min_humidity = float(humidity)
             except ValueError:
@@ -610,7 +610,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_max_humidity(self, humidity):
-        if humidity not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if humidity not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 self._attr_max_humidity = float(humidity)
             except ValueError:
@@ -618,7 +618,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_target_humidity(self, humidity):
-        if humidity not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if humidity not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 new_humidity = float(humidity)
                 if (
@@ -631,7 +631,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_target_temp(self, temp):
-        if temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if temp not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 # Update the internal state without triggering the set_temperature action
                 new_target_temp = float(temp)
@@ -645,7 +645,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_target_temp_high(self, temp):
-        if temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if temp not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 # Update the internal state without triggering the set_temperature action
                 new_target_temp_high = float(temp)
@@ -657,7 +657,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
 
     @callback
     def _update_target_temp_low(self, temp):
-        if temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        if temp not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 # Update the internal state without triggering the set_temperature action
                 new_target_temp_low = float(temp)
@@ -674,7 +674,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
             if self._attr_hvac_mode != hvac_mode:  # Only update if there's a change
                 self._attr_hvac_mode = hvac_mode
                 self.async_write_ha_state()  # Update HA state without triggering an action
-        elif hvac_mode not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        elif hvac_mode not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             _LOGGER.error(
                 "Received invalid hvac mode: %s. Expected: %s.",
                 hvac_mode,
@@ -687,7 +687,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
             if self._attr_preset_mode != preset_mode:  # Only update if there's a change
                 self._attr_preset_mode = preset_mode
                 self.async_write_ha_state()  # Update HA state without triggering an action
-        elif preset_mode not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        elif preset_mode not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             _LOGGER.error(
                 "Received invalid preset mode %s. Expected %s.",
                 preset_mode,
@@ -701,7 +701,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
             if self._attr_fan_mode != fan_mode_str:  # Only update if there's a change
                 self._attr_fan_mode = fan_mode_str
                 self.async_write_ha_state()  # Update HA state without triggering an action
-        elif fan_mode not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        elif fan_mode not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             _LOGGER.error(
                 "Received invalid fan mode: %s (str: %s). Expected: %s.",
                 fan_mode,
@@ -715,7 +715,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
             if self._attr_swing_mode != swing_mode:  # Only update if there's a change
                 self._attr_swing_mode = swing_mode
                 self.async_write_ha_state()  # Update HA state without triggering an action
-        elif swing_mode not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        elif swing_mode not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             _LOGGER.error(
                 "Received invalid swing mode: %s. Expected: %s.",
                 swing_mode,
@@ -728,7 +728,7 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
             if self._attr_hvac_action != hvac_action:  # Only update if there's a change
                 self._attr_hvac_action = hvac_action
                 self.async_write_ha_state()  # Update HA state without triggering an action
-        elif hvac_action not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+        elif hvac_action not in (None, STATE_UNKNOWN, STATE_UNAVAILABLE):
             _LOGGER.error(
                 "Received invalid hvac action: %s. Expected: %s.",
                 hvac_action,


### PR DESCRIPTION
Closes #117

### Problem

`state_attr()` returns `None` — not a string — when the source entity is missing or unavailable. Every state-handler callback guards only against the *strings* `STATE_UNKNOWN` / `STATE_UNAVAILABLE`, so `None` falls straight through to `float()`/`int()`:

```
File "custom_components/climate_template/climate.py", line 591, in _update_current_temp
    self._attr_current_temperature = float(temp)
TypeError: float() argument must be a string or a real number, not 'NoneType'
```

Config that triggers it:

```yaml
- platform: climate_template
  name: "Master Bedroom Auto"
  current_temperature_template: "{{ state_attr('climate.master_bedroom', 'current_temperature') }}"
```

When the source zone drops out, `state_attr` yields `None`. Worth noting this fires on *every* state change of the source entity while it is unavailable, not only at startup as #117 describes.

### Fix

Add `None` to the sentinel tuple in all 15 handlers.

In the numeric handlers (`_update_min_temp`, `_update_max_temp`, `_update_current_temp`, the four humidity handlers, and the three target-temperature handlers) this prevents the `TypeError`. In the mode handlers (`_update_hvac_mode`, `_update_preset_mode`, `_update_fan_mode`, `_update_swing_mode`, `_update_hvac_action`) the branch only emits `_LOGGER.error("Received invalid ...")`, so this suppresses a spurious error when the source is merely unavailable — the same intent as the existing sentinels.

No behaviour change when templates render normally.

### Notes

- Scoped deliberately to `None` rather than switching to a positive `isinstance(temp, (int, float, str))` check, to keep the change minimal.
- Based on `main`, independent of #150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6qHpuFJDAavAGsfB4fvXm
