### PR TITLE
Fix template schema import on Home Assistant 2026.9

### DIFF
--- a/custom_components/climate_template/climate.py
+++ b/custom_components/climate_template/climate.py
@@ -50,7 +50,15 @@ from homeassistant.components.template.const import (
 from homeassistant.components.template.helpers import (
     async_create_template_tracking_entities,
 )
-from homeassistant.components.template.schemas import make_template_entity_base_schema
+
+try:
+    from homeassistant.components.template.schemas import (
+        make_template_entity_common_schema,
+    )
+except ImportError:
+    from homeassistant.components.template.schemas import (
+        make_template_entity_base_schema as make_template_entity_common_schema,
+    )
 from homeassistant.components.template.template_entity import TemplateEntity
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -121,7 +129,7 @@ DOMAIN = "climate_template"
 PLATFORMS = ["climate"]
 
 PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
-    make_template_entity_base_schema(CLIMATE_DOMAIN, DEFAULT_NAME).schema
+    make_template_entity_common_schema(CLIMATE_DOMAIN, DEFAULT_NAME).schema
 ).extend(
     {
         vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,


### PR DESCRIPTION
## Summary

- use `make_template_entity_common_schema` after the schema helper rename in Home Assistant 2026.9
- fall back to `make_template_entity_base_schema` on older supported Home Assistant releases
- preserve the currently declared HACS minimum version instead of requiring 2026.9

Home Assistant removed the old helper in home-assistant/core#178762. The compatibility import keeps both API generations working. This also retains `.schema` when extending `PLATFORM_SCHEMA`.

Related to #150 and #153. This variant preserves the existing HACS compatibility floor and retains the schema mapping required by `Schema.extend()`.

## Testing

- `python3 -m py_compile custom_components/climate_template/climate.py`
- Black format check
- imported the integration and constructed `PLATFORM_SCHEMA` in the official Home Assistant 2025.9.0 container
- imported the integration and constructed `PLATFORM_SCHEMA` in the official Home Assistant 2026.9.0 container

Fixes #151