### PR TITLE
Refactor temperature retrieval with None check

### DIFF
--- a/custom_components/climate_template/climate.py
+++ b/custom_components/climate_template/climate.py
@@ -404,10 +404,11 @@ class TemplateClimate(TemplateEntity, ClimateEntity, RestoreEntity):
             if previous_state.state in self._attr_hvac_modes:
                 self._attr_hvac_mode = HVACMode(previous_state.state)
 
-            if temperature := previous_state.attributes.get(
-                ATTR_TEMPERATURE, DEFAULT_TEMP
-            ):
+            if (
+                temperature := previous_state.attributes.get(ATTR_TEMPERATURE)
+            ) is not None:
                 self._attr_target_temperature = float(temperature)
+                
             if temperature_high := previous_state.attributes.get(ATTR_TARGET_TEMP_HIGH):
                 self._attr_target_temperature_high = float(temperature_high)
             if temperature_low := previous_state.attributes.get(ATTR_TARGET_TEMP_LOW):


### PR DESCRIPTION
## Problem

When the target temperature is set to `0` and Home Assistant restarts,
the climate entity resets to `21` (`DEFAULT_TEMP`). Any other value
(e.g. 1–15) is restored correctly — only `0` is affected.

## Cause

In `async_added_to_hass` the restored temperature is checked for
truthiness via the walrus operator:

```python
if temperature := previous_state.attributes.get(ATTR_TEMPERATURE, DEFAULT_TEMP):
    self._attr_target_temperature = float(temperature)
```

When the stored value is `0`, the condition evaluates to `False`
(0 is falsy in Python), so the restore is skipped and the entity
keeps the `DEFAULT_TEMP` (21) assigned in `__init__`.

## Fix

Check explicitly for `None` instead of truthiness:

```python
if (temperature := previous_state.attributes.get(ATTR_TEMPERATURE)) is not None:
    self._attr_target_temperature = float(temperature)
```

The `DEFAULT_TEMP` fallback in `.get()` is redundant and has been
removed: if the attribute is missing, the default set in `__init__`
already applies.

## Testing

- Set target temperature to 0, restart HA → 0 is now restored
- Set target temperature to e.g. 5 or 21, restart HA → still restored correctly
- No previous state (fresh entity) → defaults to 21 as before